### PR TITLE
QOLOE-54 add fira sans font to site header

### DIFF
--- a/src/components/bs5/header/header.scss
+++ b/src/components/bs5/header/header.scss
@@ -354,6 +354,7 @@
 			display: flex;
 			flex-direction: column;
 			justify-content: center;
+			font-family: "Fira Sans";
 
 			.qld__header__secondary-image {
 				height: 2.5rem;

--- a/src/components/bs5/header/header.scss
+++ b/src/components/bs5/header/header.scss
@@ -354,7 +354,6 @@
 			display: flex;
 			flex-direction: column;
 			justify-content: center;
-			font-family: "Fira Sans";
 
 			.qld__header__secondary-image {
 				height: 2.5rem;
@@ -366,7 +365,7 @@
 
 			.qld__header__heading {
 				color: var(--#{$prefix}header__site-name__heading__text_color);
-				font-family: $font-family-sans-serif;
+				font-family: $font-family-sitename;
 				font-size: 1rem;
 				font-weight: 700;
 				line-height: 1.25;

--- a/src/main.scss
+++ b/src/main.scss
@@ -7,6 +7,7 @@
 // External fonts
 @import url('https://fonts.googleapis.com/css2?family=Fira+Sans:wght@400;700&family=Noto+Sans:wght@400;600&display=swap');
 $font-family-sans-serif: "Noto Sans", system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" !default;
+$font-family-sitename: "Fira Sans";
 
 //Icons
 @import url("https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.css");


### PR DESCRIPTION
Adding Google Font "Fira Sans" to the Header Site Name

https://fonts.google.com/specimen/Fira+Sans?preview.text=For%20Government&query=fira+sans

![image](https://github.com/qld-gov-au/qgds-qol-mvp/assets/126438309/ab565acf-d4e3-4717-804f-4777bdf9b135)
