### PR TITLE
QOLOE-9 Fix for PageAlert color and optional heading

### DIFF
--- a/src/components/bs5/inpageAlert/inpageAlert.hbs
+++ b/src/components/bs5/inpageAlert/inpageAlert.hbs
@@ -1,6 +1,6 @@
 <div class="alert {{variantClass}} {{customClass}}" role="alert">
     {{#if heading}}
-    <h4 class="alert-heading">{{{ heading }}}</h4>
+    <div class="alert-heading" role="heading">{{{ heading }}}</div>
     {{/if}}
     {{{ content }}}
 </div>

--- a/src/components/bs5/inpageAlert/inpageAlert.hbs
+++ b/src/components/bs5/inpageAlert/inpageAlert.hbs
@@ -1,4 +1,6 @@
 <div class="alert {{variantClass}} {{customClass}}" role="alert">
+    {{#if heading}}
     <h4 class="alert-heading">{{{ heading }}}</h4>
+    {{/if}}
     {{{ content }}}
 </div>

--- a/src/components/bs5/inpageAlert/inpageAlert.scss
+++ b/src/components/bs5/inpageAlert/inpageAlert.scss
@@ -32,6 +32,7 @@
     .alert-heading {
         line-height: 1.5;
         font-size: 1.5rem;
+        font-weight: 600;
         margin: 0 0 1rem 0;
         padding: 0;
         color: var(--qld-headings-color);

--- a/src/components/bs5/inpageAlert/inpageAlert.scss
+++ b/src/components/bs5/inpageAlert/inpageAlert.scss
@@ -9,9 +9,9 @@
 .light-alt .alert,
 .dark .alert,
 .dark-alt .alert {
-
     --qld-headings-color: var(--#{$prefix}light-text-text);
     --qld-body-color: var(--#{$prefix}light-text-text);
+    --qld-alert-color: var(--#{$prefix}light-text-text);
     --qld-alert-bg: #FFF;
     --qld-link-color: #{$link-color};
     --qld-link-hover-color: #{$link-hover-color};


### PR DESCRIPTION
- Changes alert color to match qld-body-color
- Heading is now optional in hbs template to support existing in-situ alerts