### PR TITLE
[QOLOE-124] Display video without thumbnail and added url params on iframe API

### DIFF
--- a/src/components/bs5/video/video.data.json
+++ b/src/components/bs5/video/video.data.json
@@ -1,21 +1,4 @@
 {
-  "vimeo": {
-    "source": "vimeo",
-    "videoId": "251763826",
-    "videoSize": "col-8",
-    "aspectRatio": "4x3",
-    "duration": "5:00",
-    "thumbnail": "./assets/img/banner-example-3-to-2.jpg",
-    "urlParams": {
-      "autoplay": false,
-      "background": true,
-      "controls": false
-    },
-    "analyticsTrackingCode": "",
-    "description": "<h3>Vimeo video embed</h3><p>Fusce posuere, magna sed pulvinar ultricies, purus lectus malesuada libero, sit amet commodo magna eros quis urna. Nunc viverra imperdiet enim.</p>",
-    "transcriptContent": "<p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Maecenas porttitor congue massa. Fusce posuere, magna sed pulvinar ultricies, purus lectus malesuada libero, sit amet commodo magna eros quis urna. Nunc viverra imperdiet enim. Fusce est. Vivamus a tellus.</p><p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Proin pharetra nonummy pede. Mauris et orci. Aenean nec lorem. In porttitor. Donec laoreet nonummy augue.</p><p>Suspendisse dui purus, scelerisque at, vulputate vitae, pretium mattis, nunc. Mauris eget neque at sem venenatis eleifend. Ut nonummy. Fusce aliquet pede non pede. Suspendisse dapibus lorem pellentesque magna. Integer nulla.</p>",
-    "transcript": ""
-  },
   "youtube": {
     "source": "youtube",
     "videoId": "LDU_Txk06tM",
@@ -24,11 +7,28 @@
     "duration": "3:12",
     "thumbnail": "https://img.youtube.com/vi/LDU_Txk06tM/sddefault.jpg",
     "urlParams": {
-      "autoplay": false,
-      "controls": false
+      "autoplay": 1,
+      "controls": 0
     },
     "description": "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Maecenas porttitor congue massa.",
     "transcriptContent": "<p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Maecenas porttitor congue massa. Fusce posuere, magna sed pulvinar ultricies, purus lectus malesuada libero, sit amet commodo magna eros quis urna. Nunc viverra imperdiet enim. Fusce est. Vivamus a tellus.</p><p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Proin pharetra nonummy pede. Mauris et orci. Aenean nec lorem. In porttitor. Donec laoreet nonummy augue.</p><p>Suspendisse dui purus, scelerisque at, vulputate vitae, pretium mattis, nunc. Mauris eget neque at sem venenatis eleifend. Ut nonummy. Fusce aliquet pede non pede. Suspendisse dapibus lorem pellentesque magna. Integer nulla.</p><p>Donec blandit feugiat ligula. Donec hendrerit, felis et imperdiet euismod, purus ipsum pretium metus, in lacinia nulla nisl eget sapien. Donec ut est in lectus consequat consequat. Etiam eget dui. Aliquam erat volutpat. Sed at lorem in nunc porta tristique.</p><p>Proin nec augue. Quisque aliquam tempor magna. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Nunc ac magna. Maecenas odio dolor, vulputate vel, auctor ac, accumsan id, felis. Pellentesque cursus sagittis felis.</p><p>Pellentesque porttitor, velit lacinia egestas auctor, diam eros tempus arcu, nec vulputate augue magna vel risus. Cras non magna vel ante adipiscing rhoncus. Vivamus a mi. Morbi neque. Aliquam erat volutpat. Integer ultrices lobortis eros.</p><p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Proin semper, ante vitae sollicitudin posuere, metus quam iaculis nibh, vitae scelerisque nunc massa eget pede. Sed velit urna, interdum vel, ultricies vel, faucibus at, quam. Donec elit est, consectetuer eget, consequat quis, tempus quis, wisi. In in nunc. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos hymenaeos.</p><p>Donec ullamcorper fringilla eros. Fusce in sapien eu purus dapibus commodo. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Cras faucibus condimentum odio. Sed ac ligula. Aliquam at eros.</p><p>Etiam at ligula et tellus ullamcorper ultrices. In fermentum, lorem non cursus porttitor, diam urna accumsan lacus, sed interdum wisi nibh nec nisl. Ut tincidunt volutpat urna. Mauris eleifend nulla eget mauris. Sed cursus quam id felis. Curabitur posuere quam vel nibh.</p><p>Cras dapibus dapibus nisl. Vestibulum quis dolor a felis congue vehicula. Maecenas pede purus, tristique ac, tempus eget, egestas quis, mauris. Curabitur non eros. Nullam hendrerit bibendum justo. Fusce iaculis, est quis lacinia pretium, pede metus molestie lacus, at gravida wisi ante at libero.</p>",
+    "transcript": ""
+  },
+  "vimeo": {
+    "source": "vimeo",
+    "videoId": "251763826",
+    "videoSize": "col-8",
+    "aspectRatio": "4x3",
+    "duration": "5:00",
+    "thumbnail": "./assets/img/banner-example-3-to-2.jpg",
+    "urlParams": {
+      "autoplay": 0,
+      "background": 1,
+      "controls": 0
+    },
+    "analyticsTrackingCode": "",
+    "description": "<h3>Vimeo video embed</h3><p>Fusce posuere, magna sed pulvinar ultricies, purus lectus malesuada libero, sit amet commodo magna eros quis urna. Nunc viverra imperdiet enim.</p>",
+    "transcriptContent": "<p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Maecenas porttitor congue massa. Fusce posuere, magna sed pulvinar ultricies, purus lectus malesuada libero, sit amet commodo magna eros quis urna. Nunc viverra imperdiet enim. Fusce est. Vivamus a tellus.</p><p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Proin pharetra nonummy pede. Mauris et orci. Aenean nec lorem. In porttitor. Donec laoreet nonummy augue.</p><p>Suspendisse dui purus, scelerisque at, vulputate vitae, pretium mattis, nunc. Mauris eget neque at sem venenatis eleifend. Ut nonummy. Fusce aliquet pede non pede. Suspendisse dapibus lorem pellentesque magna. Integer nulla.</p>",
     "transcript": ""
   },
   "custom": {

--- a/src/components/bs5/video/video.data.json
+++ b/src/components/bs5/video/video.data.json
@@ -6,6 +6,11 @@
     "aspectRatio": "4x3",
     "duration": "5:00",
     "thumbnail": "./assets/img/banner-example-3-to-2.jpg",
+    "urlParams": {
+      "autoplay": false,
+      "background": true,
+      "controls": false
+    },
     "analyticsTrackingCode": "",
     "description": "<h3>Vimeo video embed</h3><p>Fusce posuere, magna sed pulvinar ultricies, purus lectus malesuada libero, sit amet commodo magna eros quis urna. Nunc viverra imperdiet enim.</p>",
     "transcriptContent": "<p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Maecenas porttitor congue massa. Fusce posuere, magna sed pulvinar ultricies, purus lectus malesuada libero, sit amet commodo magna eros quis urna. Nunc viverra imperdiet enim. Fusce est. Vivamus a tellus.</p><p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Proin pharetra nonummy pede. Mauris et orci. Aenean nec lorem. In porttitor. Donec laoreet nonummy augue.</p><p>Suspendisse dui purus, scelerisque at, vulputate vitae, pretium mattis, nunc. Mauris eget neque at sem venenatis eleifend. Ut nonummy. Fusce aliquet pede non pede. Suspendisse dapibus lorem pellentesque magna. Integer nulla.</p>",
@@ -18,6 +23,10 @@
     "aspectRatio": "16x9",
     "duration": "3:12",
     "thumbnail": "https://img.youtube.com/vi/LDU_Txk06tM/sddefault.jpg",
+    "urlParams": {
+      "autoplay": false,
+      "controls": false
+    },
     "description": "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Maecenas porttitor congue massa.",
     "transcriptContent": "<p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Maecenas porttitor congue massa. Fusce posuere, magna sed pulvinar ultricies, purus lectus malesuada libero, sit amet commodo magna eros quis urna. Nunc viverra imperdiet enim. Fusce est. Vivamus a tellus.</p><p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Proin pharetra nonummy pede. Mauris et orci. Aenean nec lorem. In porttitor. Donec laoreet nonummy augue.</p><p>Suspendisse dui purus, scelerisque at, vulputate vitae, pretium mattis, nunc. Mauris eget neque at sem venenatis eleifend. Ut nonummy. Fusce aliquet pede non pede. Suspendisse dapibus lorem pellentesque magna. Integer nulla.</p><p>Donec blandit feugiat ligula. Donec hendrerit, felis et imperdiet euismod, purus ipsum pretium metus, in lacinia nulla nisl eget sapien. Donec ut est in lectus consequat consequat. Etiam eget dui. Aliquam erat volutpat. Sed at lorem in nunc porta tristique.</p><p>Proin nec augue. Quisque aliquam tempor magna. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Nunc ac magna. Maecenas odio dolor, vulputate vel, auctor ac, accumsan id, felis. Pellentesque cursus sagittis felis.</p><p>Pellentesque porttitor, velit lacinia egestas auctor, diam eros tempus arcu, nec vulputate augue magna vel risus. Cras non magna vel ante adipiscing rhoncus. Vivamus a mi. Morbi neque. Aliquam erat volutpat. Integer ultrices lobortis eros.</p><p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Proin semper, ante vitae sollicitudin posuere, metus quam iaculis nibh, vitae scelerisque nunc massa eget pede. Sed velit urna, interdum vel, ultricies vel, faucibus at, quam. Donec elit est, consectetuer eget, consequat quis, tempus quis, wisi. In in nunc. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos hymenaeos.</p><p>Donec ullamcorper fringilla eros. Fusce in sapien eu purus dapibus commodo. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Cras faucibus condimentum odio. Sed ac ligula. Aliquam at eros.</p><p>Etiam at ligula et tellus ullamcorper ultrices. In fermentum, lorem non cursus porttitor, diam urna accumsan lacus, sed interdum wisi nibh nec nisl. Ut tincidunt volutpat urna. Mauris eleifend nulla eget mauris. Sed cursus quam id felis. Curabitur posuere quam vel nibh.</p><p>Cras dapibus dapibus nisl. Vestibulum quis dolor a felis congue vehicula. Maecenas pede purus, tristique ac, tempus eget, egestas quis, mauris. Curabitur non eros. Nullam hendrerit bibendum justo. Fusce iaculis, est quis lacinia pretium, pede metus molestie lacus, at gravida wisi ante at libero.</p>",
     "transcript": ""

--- a/src/components/bs5/video/video.data.json
+++ b/src/components/bs5/video/video.data.json
@@ -7,7 +7,7 @@
     "duration": "3:12",
     "thumbnail": "https://img.youtube.com/vi/LDU_Txk06tM/sddefault.jpg",
     "urlParams": {
-      "autoplay": 1,
+      "autoplay": 0,
       "controls": 0
     },
     "description": "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Maecenas porttitor congue massa.",
@@ -23,7 +23,7 @@
     "thumbnail": "./assets/img/banner-example-3-to-2.jpg",
     "urlParams": {
       "autoplay": 0,
-      "background": 1,
+      "background": 0,
       "controls": 0
     },
     "analyticsTrackingCode": "",

--- a/src/components/bs5/video/video.hbs
+++ b/src/components/bs5/video/video.hbs
@@ -5,12 +5,14 @@
 </script>
 {{/if}}
 
-{{! Add 'not-ready' css when thumbnail exists to hide video-embed DIV. 
-    When thumbnail does not exist, the video embed will be displayed on page load.
-}}
-<section class="video {{#if thumbnail}}not-ready{{/if}} {{videoSize}}">
+{{! By default, 'not-ready' class is added and will be removed by javascript event handler.
+    When thumbnail attribute is empty / does not exist, 'empty-thumbnail' css class is added. }}
+<section class="video not-ready {{#ifCond thumbnail '==' ''}}empty-thumbnail{{/ifCond}} {{videoSize}}">
     <div class="video-player ratio ratio-{{aspectRatio}}">
-        <a href="#" class="video-thumbnail" style="--thumbnail:url({{thumbnail}})">
+
+        <a href="#" class="video-thumbnail video-controls">
+            <div class="video-thumbnail-image" style="--thumbnail:url({{thumbnail}})"></div>
+
             <div class="video-nav">
                 <div class="video-watch"><span class="icon"></span><span>Watch</span></div>
 

--- a/src/components/bs5/video/video.hbs
+++ b/src/components/bs5/video/video.hbs
@@ -5,11 +5,12 @@
 </script>
 {{/if}}
 
-
-<section class="video not-ready {{videoSize}}">
+{{! Add 'not-ready' css when thumbnail exists to hide video-embed DIV. 
+    When thumbnail does not exist, the video embed will be displayed on page load.
+}}
+<section class="video {{#if thumbnail}}not-ready{{/if}} {{videoSize}}">
     <div class="video-player ratio ratio-{{aspectRatio}}">
         <a href="#" class="video-thumbnail" style="--thumbnail:url({{thumbnail}})">
-
             <div class="video-nav">
                 <div class="video-watch"><span class="icon"></span><span>Watch</span></div>
 
@@ -21,25 +22,21 @@
 
         <div class="video-embed ratio ratio-{{aspectRatio}}">
             {{#ifCond source '===' 'vimeo'}}
-                <iframe title="Vimeo video" class="embed-responsive-item video-vimeo" allow="autoplay; fullscreen" allowfullscreen muted="muted" src="https://player.vimeo.com/video/{{videoId}}?rel=0"></iframe>
+                <iframe title="Vimeo video" class="embed-responsive-item video-vimeo" allow="autoplay; fullscreen" allowfullscreen muted="muted" src="https://player.vimeo.com/video/{{videoId}}?rel=0&autoplay={{urlParams.autoplay}}&background={{urlParams.background}}&controls={{url.Params.controls}}"></iframe>
 
             {{else ifCond source '===' 'youtube'}}
-                <iframe title="YouTube video" class="embed-responsive-item video-youtube" allow="autoplay; fullscreen" allowfullscreen src="https://www.youtube.com/embed/{{videoId}}?rel=0"></iframe>
+                <iframe title="YouTube video" class="embed-responsive-item video-youtube" allow="autoplay; fullscreen" allowfullscreen src="https://www.youtube.com/embed/{{videoId}}?rel=0&autoplay={{urlParams.autoplay}}&controls={{url.Params.controls}}"></iframe>
 
             {{else ifCond source '===' 'custom'}}
-            <iframe title="Custom video" class="embed-responsive-item video-custom" allow="autoplay; fullscreen" allowfullscreen
+                <iframe title="Custom video" class="embed-responsive-item video-custom" allow="autoplay; fullscreen" allowfullscreen
                 src="{{videoId}}"></iframe>
 
             {{else}}
-
-            <p class="text-center position-absolute top-50">A video has not been provided.</p>
+                <p class="text-center position-absolute top-50">A video has not been provided.</p>
 
             {{/ifCond}}
         </div>
-
     </div>
-
-
 
     <div class="video-description">
         {{{ description }}}

--- a/src/components/bs5/video/video.hbs
+++ b/src/components/bs5/video/video.hbs
@@ -22,10 +22,10 @@
 
         <div class="video-embed ratio ratio-{{aspectRatio}}">
             {{#ifCond source '===' 'vimeo'}}
-                <iframe title="Vimeo video" class="embed-responsive-item video-vimeo" allow="autoplay; fullscreen" allowfullscreen muted="muted" src="https://player.vimeo.com/video/{{videoId}}?rel=0&autoplay={{urlParams.autoplay}}&background={{urlParams.background}}&controls={{url.Params.controls}}"></iframe>
+                <iframe title="Vimeo video" class="embed-responsive-item video-vimeo" allow="autoplay; fullscreen" allowfullscreen muted="muted" src="https://player.vimeo.com/video/{{videoId}}?rel=0&autoplay={{urlParams.autoplay}}&background={{urlParams.background}}&controls={{urlParams.controls}}"></iframe>
 
             {{else ifCond source '===' 'youtube'}}
-                <iframe title="YouTube video" class="embed-responsive-item video-youtube" allow="autoplay; fullscreen" allowfullscreen src="https://www.youtube.com/embed/{{videoId}}?rel=0&autoplay={{urlParams.autoplay}}&controls={{url.Params.controls}}"></iframe>
+                <iframe title="YouTube video" class="embed-responsive-item video-youtube" allow="autoplay; fullscreen" allowfullscreen src="https://www.youtube.com/embed/{{videoId}}?rel=0&autoplay={{urlParams.autoplay}}&controls={{urlParams.controls}}"></iframe>
 
             {{else ifCond source '===' 'custom'}}
                 <iframe title="Custom video" class="embed-responsive-item video-custom" allow="autoplay; fullscreen" allowfullscreen

--- a/src/components/bs5/video/video.hbs
+++ b/src/components/bs5/video/video.hbs
@@ -7,7 +7,7 @@
 
 {{! By default, 'not-ready' class is added and will be removed by javascript event handler.
     When thumbnail attribute is empty / does not exist, 'empty-thumbnail' css class is added. }}
-<section class="video not-ready {{#ifCond thumbnail '==' ''}}empty-thumbnail{{/ifCond}} {{videoSize}}">
+<section class="video not-ready {{#unless thumbnail}}empty-thumbnail{{/unless}} {{videoSize}}">
     <div class="video-player ratio ratio-{{aspectRatio}}">
 
         <a href="#" class="video-thumbnail video-controls">

--- a/src/components/bs5/video/video.scss
+++ b/src/components/bs5/video/video.scss
@@ -75,10 +75,6 @@ $video-clock-icon-dark: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/20
   }
 
   &-thumbnail {
-    background-image: var(--thumbnail);
-    background-position: center center;
-    background-repeat: no-repeat;
-    background-size: cover;
     display: block;
     opacity: 0;
 
@@ -109,6 +105,36 @@ $video-clock-icon-dark: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/20
           text-decoration-thickness: var(--qld-link-underline-thickness);
         }
       }
+
+      .video-thumbnail-image {
+        &:before {
+          opacity: .15;
+        }
+      }
+    }
+
+    .video-thumbnail-image {
+      background-image: var(--thumbnail);
+      background-position: center center;
+      background-repeat: no-repeat;
+      background-size: cover;
+      display: block;
+      opacity: 0;
+      width: 100%;
+      height: 100%;
+
+      &:before {
+        content: "";
+        background-color: var(--#{$prefix}video-nav-bg);
+        opacity: 0;
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        -webkit-transition: opacity .25s ease-in-out;
+        transition: opacity .25s ease-in-out;
+      }
     }
   }
 
@@ -120,10 +146,21 @@ $video-clock-icon-dark: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/20
     .video-thumbnail {
       z-index: 1;
       opacity: 1;
-
+    }
+    .video-thumbnail-image {
+      opacity: 1;
     }
     .video-embed {
       opacity: 0;
+    }
+  }
+
+  &.empty-thumbnail {
+    .video-thumbnail-image {
+      opacity: 0;
+    }
+    .video-embed {
+      opacity: 1;
     }
   }
 

--- a/src/components/bs5/video/video.stories.js
+++ b/src/components/bs5/video/video.stories.js
@@ -5,6 +5,10 @@ import defaultdata from './video.data.json';
 // include accordion for transcript
 import { Accordion } from "../accordion/Accordion.js";
 
+/** 
+ * Set default arguments for the Video component,
+ * which is based on YouTube arguments.
+ */
 export default {
   tags: ["autodocs"],
   title: "Components/Video",
@@ -44,6 +48,20 @@ export default {
         "Full width": "col-12",
         "Two thirds": "col-8",
         "Half page": "col-6",
+      },
+    },
+    urlParams: {
+      control: {
+        type: "object",
+        autoplay: {
+          type: "boolean",
+        },
+        background: {
+          type: "boolean",
+        },
+        controls: {
+          type: "boolean",
+        },
       },
     },
   },

--- a/src/components/bs5/video/video.stories.js
+++ b/src/components/bs5/video/video.stories.js
@@ -53,15 +53,6 @@ export default {
     urlParams: {
       control: {
         type: "object",
-        autoplay: {
-          type: "boolean",
-        },
-        background: {
-          type: "boolean",
-        },
-        controls: {
-          type: "boolean",
-        },
       },
     },
   },


### PR DESCRIPTION
[QOLOE-124] Display video without thumbnail and added url params on iframe API:

- Allow video to display when thumbnail attribute is empty and hiding video thumbnail. 
  I have added a conditional check to only apply 'not-ready' css when thumbnail is not empty.
- Add URL Params for Youtube and Vimeo iFrame API:
  -- Youtube: autoplay, controls 
  -- Vimeo: autoplay, background, controls



[QOLOE-124]: https://ssq-qol.atlassian.net/browse/QOLOE-124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ