### PR TITLE
[QOLOE-124] Fix video iFrame autoplay and other minor adjustments

### DIFF
--- a/src/components/bs5/video/video.data.json
+++ b/src/components/bs5/video/video.data.json
@@ -8,11 +8,11 @@
     "thumbnail": "https://img.youtube.com/vi/LDU_Txk06tM/sddefault.jpg",
     "urlParams": {
       "autoplay": 0,
-      "controls": 0
+      "controls": 1
     },
     "description": "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Maecenas porttitor congue massa.",
     "transcriptContent": "<p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Maecenas porttitor congue massa. Fusce posuere, magna sed pulvinar ultricies, purus lectus malesuada libero, sit amet commodo magna eros quis urna. Nunc viverra imperdiet enim. Fusce est. Vivamus a tellus.</p><p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Proin pharetra nonummy pede. Mauris et orci. Aenean nec lorem. In porttitor. Donec laoreet nonummy augue.</p><p>Suspendisse dui purus, scelerisque at, vulputate vitae, pretium mattis, nunc. Mauris eget neque at sem venenatis eleifend. Ut nonummy. Fusce aliquet pede non pede. Suspendisse dapibus lorem pellentesque magna. Integer nulla.</p><p>Donec blandit feugiat ligula. Donec hendrerit, felis et imperdiet euismod, purus ipsum pretium metus, in lacinia nulla nisl eget sapien. Donec ut est in lectus consequat consequat. Etiam eget dui. Aliquam erat volutpat. Sed at lorem in nunc porta tristique.</p><p>Proin nec augue. Quisque aliquam tempor magna. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Nunc ac magna. Maecenas odio dolor, vulputate vel, auctor ac, accumsan id, felis. Pellentesque cursus sagittis felis.</p><p>Pellentesque porttitor, velit lacinia egestas auctor, diam eros tempus arcu, nec vulputate augue magna vel risus. Cras non magna vel ante adipiscing rhoncus. Vivamus a mi. Morbi neque. Aliquam erat volutpat. Integer ultrices lobortis eros.</p><p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Proin semper, ante vitae sollicitudin posuere, metus quam iaculis nibh, vitae scelerisque nunc massa eget pede. Sed velit urna, interdum vel, ultricies vel, faucibus at, quam. Donec elit est, consectetuer eget, consequat quis, tempus quis, wisi. In in nunc. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos hymenaeos.</p><p>Donec ullamcorper fringilla eros. Fusce in sapien eu purus dapibus commodo. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Cras faucibus condimentum odio. Sed ac ligula. Aliquam at eros.</p><p>Etiam at ligula et tellus ullamcorper ultrices. In fermentum, lorem non cursus porttitor, diam urna accumsan lacus, sed interdum wisi nibh nec nisl. Ut tincidunt volutpat urna. Mauris eleifend nulla eget mauris. Sed cursus quam id felis. Curabitur posuere quam vel nibh.</p><p>Cras dapibus dapibus nisl. Vestibulum quis dolor a felis congue vehicula. Maecenas pede purus, tristique ac, tempus eget, egestas quis, mauris. Curabitur non eros. Nullam hendrerit bibendum justo. Fusce iaculis, est quis lacinia pretium, pede metus molestie lacus, at gravida wisi ante at libero.</p>",
-    "transcript": ""
+    "transcriptAccordion": ""
   },
   "vimeo": {
     "source": "vimeo",
@@ -24,12 +24,12 @@
     "urlParams": {
       "autoplay": 0,
       "background": 0,
-      "controls": 0
+      "controls": 1
     },
     "analyticsTrackingCode": "",
     "description": "<h3>Vimeo video embed</h3><p>Fusce posuere, magna sed pulvinar ultricies, purus lectus malesuada libero, sit amet commodo magna eros quis urna. Nunc viverra imperdiet enim.</p>",
     "transcriptContent": "<p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Maecenas porttitor congue massa. Fusce posuere, magna sed pulvinar ultricies, purus lectus malesuada libero, sit amet commodo magna eros quis urna. Nunc viverra imperdiet enim. Fusce est. Vivamus a tellus.</p><p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Proin pharetra nonummy pede. Mauris et orci. Aenean nec lorem. In porttitor. Donec laoreet nonummy augue.</p><p>Suspendisse dui purus, scelerisque at, vulputate vitae, pretium mattis, nunc. Mauris eget neque at sem venenatis eleifend. Ut nonummy. Fusce aliquet pede non pede. Suspendisse dapibus lorem pellentesque magna. Integer nulla.</p>",
-    "transcript": ""
+    "transcriptAccordion": ""
   },
   "custom": {
     "source": "custom",
@@ -41,6 +41,6 @@
     "analyticsTrackingCode": "",
     "description": "<h3>Custom video embed</h3><p>Fusce posuere, magna sed pulvinar ultricies, purus lectus malesuada libero, sit amet commodo magna eros quis urna. Nunc viverra imperdiet enim.</p>",
     "transcriptContent": "<p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Maecenas porttitor congue massa. Fusce posuere, magna sed pulvinar ultricies, purus lectus malesuada libero, sit amet commodo magna eros quis urna. Nunc viverra imperdiet enim. Fusce est. Vivamus a tellus.</p><p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Proin pharetra nonummy pede. Mauris et orci. Aenean nec lorem. In porttitor. Donec laoreet nonummy augue.</p><p>Suspendisse dui purus, scelerisque at, vulputate vitae, pretium mattis, nunc. Mauris eget neque at sem venenatis eleifend. Ut nonummy. Fusce aliquet pede non pede. Suspendisse dapibus lorem pellentesque magna. Integer nulla.</p>",
-    "transcript": ""
+    "transcriptAccordion": ""
   }
 }

--- a/src/components/bs5/video/video.functions.js
+++ b/src/components/bs5/video/video.functions.js
@@ -15,10 +15,11 @@ export function videoEmbedPlay(event) {
 
   component.classList.remove("not-ready")
 
-  if (
-    !iframe.classList.contains("video-custom")
-  ) {
-    iframe.src = `${iframe.src}&autoplay=1`;
+  // Parse iFrame URL and set the 'autoplay' parameter to 1.
+  if (!iframe.classList.contains("video-custom")) {
+    const url = new URL(iframe.src);
+    url.searchParams.set('autoplay', '1');
+    iframe.src = url.toString();
   }
 
   iframe.focus()

--- a/src/components/bs5/video/video.hbs
+++ b/src/components/bs5/video/video.hbs
@@ -44,6 +44,7 @@
         {{{ description }}}
     </div>
 
-    {{{transcript}}}
+    {{! Render the transcript content in an accordion template }}
+    {{{ transcriptAccordion }}}
 
 </section>

--- a/src/components/bs5/video/video.stories.js
+++ b/src/components/bs5/video/video.stories.js
@@ -14,7 +14,7 @@ export default {
   title: "Components/Video",
   args: defaultdata.youtube,
   render: (args) => {
-    const transcript = new Accordion({
+    const transcriptAccordion = new Accordion({
       groupid: `video-transcript-${args.videoId}`,
       accordionItems: [
         {
@@ -25,7 +25,7 @@ export default {
         },
       ],
     }).html;
-    return new Video({ ...args, transcript: transcript }).html;
+    return new Video({ ...args, transcriptAccordion }).html;
   },
 
   argTypes: {
@@ -72,10 +72,8 @@ export default {
     //   type: "figma",
     //   url: "https://www.figma.com/file/qKsxl3ogIlBp7dafgxXuCA/QLD-GOV-DDS?type=design&node-id=24025-293663&mode=design&t=uf49yHsvyUfA39Lv-4",
     // },
-    docs: {
-      controls: {
-        exclude: ["transcript"],
-      },
+    controls: {
+      exclude: ["transcriptAccordion"],
     },
   },
 };


### PR DESCRIPTION
[QOLOE-124] Fix video iFrame autoplay and minor adjustments:

- Fix conflicted 'autoplay' param between the one in json data and in videEmbedPlay function.
- Set the default value on video 'controls' to true so videos have controls by default. 
  CMS content editor still can hide the video controls when they see fit.
- Rename 'transcript' attribute to 'transcriptAccordion' to better reflect its purpose.

[QOLOE-124]: https://ssq-qol.atlassian.net/browse/QOLOE-124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ