### PR TITLE
Correct release auto generation (spacing typo)

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -5,9 +5,9 @@
 changelog:
   categories:
     - title: Breaking Changes 🛠
-        labels:
-          - Semver-Major
-          - breaking-change
+      labels:
+        - Semver-Major
+        - breaking-change
 
     - title: 🏕 Features
       labels:


### PR DESCRIPTION
per
https://github.com/qld-gov-au/qgds-qol-mvp/actions/runs/9247937337/job/25437500832

HTTP 422: Could not parse .github/release.yml: (<unknown>): mapping values are not allowed in this context at line 8 column 15 (https://api.github.com/repos/qld-gov-au/qgds-qol-mvp/releases)
Error: Process completed with exit code 1.
