### PR TITLE
QOLOE-12 attach event listener in shorten function

### DIFF
--- a/src/components/bs5/breadcrumbs/breadcrumb.functions.js
+++ b/src/components/bs5/breadcrumbs/breadcrumb.functions.js
@@ -25,6 +25,7 @@ export function breadcrumbShorten () {
         expandButton.setAttribute('href', 'javascript:void(0)')
         expandButton.setAttribute('aria-label', 'Expand the breadcrumbs')
         expandButton.textContent = '[...]'
+        expandButton.addEventListener('click', breadcrumbExpand)
 
         expandCrumb.appendChild(expandButton)
         crumb.after(expandCrumb)

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,7 @@
 import { accordionToggleAll, accordionToggleAllButtonState, accordionHashLinks } from "./components/bs5/accordion/accordion.functions";
 import { videoEmbedPlay, videoTranscriptTitle } from "./components/bs5/video/video.functions";
 import { initializeNavbar } from './components/bs5/navbar/navbar.functions';
-import { breadcrumbShorten, breadcrumbExpand } from "./components/bs5/breadcrumbs/breadcrumb.functions";
+import { breadcrumbShorten } from "./components/bs5/breadcrumbs/breadcrumb.functions";
 import { positionQuickExit, initQuickexit } from './components/bs5/quickexit/quickexit.functions';
 import { toggleSearch, showSuggestions } from './components/bs5/header/header.functions';
 
@@ -51,10 +51,6 @@ window.addEventListener("DOMContentLoaded", () => {
 
     // Breadcrumb
     breadcrumbShorten();
-
-    let breadcrumbToggle = document.querySelector('.breadcrumb-toggle a')
-
-    breadcrumbToggle.addEventListener("click", breadcrumbExpand)
 
     // Quick exit
     initQuickexit();


### PR DESCRIPTION
Makes sure event listener is only added when required (when breadcrumb is shortened).